### PR TITLE
Fix server crash with the Simulacrum

### DIFF
--- a/simulacrum/src/main/java/io/github/projectet/dmlSimulacrum/dmlSimulacrum.java
+++ b/simulacrum/src/main/java/io/github/projectet/dmlSimulacrum/dmlSimulacrum.java
@@ -18,6 +18,9 @@ import net.minecraft.item.Item;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
 import team.reborn.energy.api.EnergyStorage;
+import net.fabricmc.fabric.api.screenhandler.v1.ScreenHandlerRegistry;
+import net.minecraft.screen.ScreenHandlerType;
+import io.github.projectet.dmlSimulacrum.gui.SimulationChamberScreenHandler;
 
 import java.lang.reflect.Field;
 import java.util.HashMap;
@@ -26,6 +29,7 @@ public class dmlSimulacrum implements ModInitializer {
 
     public static final Block SIMULATION_CHAMBER = new SimulationChamber(FabricBlockSettings.of(Material.STONE).hardness(4f).resistance(3000f));
     public static BlockEntityType<SimulationChamberEntity> SIMULATION_CHAMBER_ENTITY;
+    public static final ScreenHandlerType<SimulationChamberScreenHandler> SCS_HANDLER_TYPE = ScreenHandlerRegistry.registerExtended(id("simulation"), SimulationChamberScreenHandler::new);
 
     public final static String MOD_ID = "dmlsimulacrum";
 

--- a/simulacrum/src/main/java/io/github/projectet/dmlSimulacrum/dmlSimulacrumClient.java
+++ b/simulacrum/src/main/java/io/github/projectet/dmlSimulacrum/dmlSimulacrumClient.java
@@ -20,7 +20,7 @@ public class dmlSimulacrumClient implements ClientModInitializer {
 
     @Override
     public void onInitializeClient() {
-        ScreenRegistry.register(SimulationChamberScreenHandler.SCS_HANDLER_TYPE, SimulationChamberScreen::new);
+        ScreenRegistry.register(dmlSimulacrum.SCS_HANDLER_TYPE, SimulationChamberScreen::new);
 
         ItemTooltipCallback.EVENT.register((item, context, lines) -> {
             World world = MinecraftClient.getInstance().world;

--- a/simulacrum/src/main/java/io/github/projectet/dmlSimulacrum/gui/SimulationChamberScreenHandler.java
+++ b/simulacrum/src/main/java/io/github/projectet/dmlSimulacrum/gui/SimulationChamberScreenHandler.java
@@ -6,6 +6,7 @@ import io.github.projectet.dmlSimulacrum.inventory.SlotSimulationChamber;
 import io.github.projectet.dmlSimulacrum.util.Constants;
 import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
 import net.fabricmc.fabric.api.screenhandler.v1.ScreenHandlerRegistry;
+import net.minecraft.screen.ScreenHandlerType;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.inventory.Inventory;
@@ -28,10 +29,8 @@ public class SimulationChamberScreenHandler extends ScreenHandler implements Con
     private World world;
     PropertyDelegate propertyDelegate;
 
-    public static final ScreenHandlerType<SimulationChamberScreenHandler> SCS_HANDLER_TYPE = ScreenHandlerRegistry.registerExtended(dmlSimulacrum.id("simulation"), SimulationChamberScreenHandler::new);
-
     public SimulationChamberScreenHandler(int syncId, PlayerInventory playerInventory, PacketByteBuf packetByteBuf) {
-        super(SCS_HANDLER_TYPE, syncId);
+        super(dmlSimulacrum.SCS_HANDLER_TYPE, syncId);
         this.player = playerInventory.player;
         this.world = this.player.world;
         this.blockPos = packetByteBuf.readBlockPos();


### PR DESCRIPTION
When using the Simulacrum on a multiplayer world, the server crashes. This PR fixes that.

(Forward-ported from the 1.18.2 backport https://github.com/9p4/DML-Backported)